### PR TITLE
如果传入一个为nil的keyValues实例化单个model对象时，返回nil

### DIFF
--- a/MJExtensionExample/MJExtensionExample/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtensionExample/MJExtensionExample/MJExtension/NSObject+MJKeyValue.m
@@ -53,6 +53,7 @@ static NSNumberFormatter *_numberFormatter;
 
 + (instancetype)objectWithKeyValues:(id)keyValues context:(NSManagedObjectContext *)context error:(NSError *__autoreleasing *)error
 {
+    if (keyValues == nil) return nil;
     if ([self isSubclassOfClass:[NSManagedObject class]] && context) {
         return [[NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self) inManagedObjectContext:context] setKeyValues:keyValues context:context error:error];
     }


### PR DESCRIPTION
如果仅仅实例化一个模型对象，传入keyValues为nil的时候，会返回一个成员变量为初始值的对象实例。这样并不是很合理吧😄