### PR TITLE
Availbility of custom the modeling class's base class.

### DIFF
--- a/MJExtension/MJFoundation.h
+++ b/MJExtension/MJFoundation.h
@@ -8,6 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-@interface MJFoundation : NSObject
+@interface MJFoundation : MJBaseObject
 + (BOOL)isClassFromFoundation:(Class)c;
 @end

--- a/MJExtension/MJFoundation.m
+++ b/MJExtension/MJFoundation.m
@@ -33,7 +33,7 @@ static NSSet *_foundationClasses;
 
 + (BOOL)isClassFromFoundation:(Class)c
 {
-    if (c == [NSObject class] || c == [NSManagedObject class]) return YES;
+    if (c == [NSObject class] || c == [MJBaseObject class] || c == [NSManagedObject class]) return YES;
     
     __block BOOL result = NO;
     [[self foundatonClasses] enumerateObjectsUsingBlock:^(Class foundationClass, BOOL *stop) {

--- a/MJExtension/MJProperty.h
+++ b/MJExtension/MJProperty.h
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
-#import "MJType.h"
 
 typedef enum {
     MJPropertyKeyTypeDictionary = 0, // 字典的key
@@ -35,7 +34,7 @@ typedef enum {
 /**
  *  包装一个成员
  */
-@interface MJProperty : NSObject
+@interface MJProperty : MJBaseObject
 
 /** 成员属性 */
 @property (nonatomic, assign) objc_property_t property;

--- a/MJExtension/MJType.h
+++ b/MJExtension/MJType.h
@@ -7,10 +7,18 @@
 //  包装一种类型
 
 #import <Foundation/Foundation.h>
+
+#ifdef MJExtension_CUSTOM_BASE_CLASS
+#define MJBaseObject    MJExtension_CUSTOM_BASE_CLASS
+#else
+#define MJBaseObject    NSObject
+#endif
+
+
 /**
  *  包装一种类型
  */
-@interface MJType : NSObject
+@interface MJType : MJBaseObject
 /** 类型标识符 */
 @property (nonatomic, copy) NSString *code;
 

--- a/MJExtension/NSObject+MJCoding.h
+++ b/MJExtension/NSObject+MJCoding.h
@@ -7,8 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "MJType.h"
+
 /**
- *  Codeing协议
+ *  Coding协议
  */
 @protocol MJCoding <NSObject>
 @optional
@@ -22,7 +24,7 @@
 + (NSArray *)ignoredCodingPropertyNames;
 @end
 
-@interface NSObject (MJCoding) <MJCoding>
+@interface MJBaseObject (MJCoding) <MJCoding>
 /**
  *  解码（从文件中解析对象）
  */

--- a/MJExtension/NSObject+MJCoding.m
+++ b/MJExtension/NSObject+MJCoding.m
@@ -10,7 +10,7 @@
 #import "NSObject+MJProperty.h"
 #import "MJProperty.h"
 
-@implementation NSObject (MJCoding)
+@implementation MJBaseObject (MJCoding)
 
 - (void)encode:(NSCoder *)encoder
 {

--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -341,7 +341,7 @@ static NSNumberFormatter *_numberFormatter;
                 value = [value keyValues];
             } else if ([value isKindOfClass:[NSArray class]]) {
                 // 3.处理数组里面有模型的情况
-                value = [NSObject keyValuesArrayWithObjectArray:value];
+                value = [MJBaseObject keyValuesArrayWithObjectArray:value];
             } else if (typeClass == [NSURL class]) {
                 value = [value absoluteString];
             }

--- a/MJExtensionExample/MJExtensionExample.xcodeproj/project.pbxproj
+++ b/MJExtensionExample/MJExtensionExample.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2D9CAF2B192FA6020011F500 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D9CAF2A192FA6020011F500 /* Foundation.framework */; };
 		2D9CAF2E192FA6020011F500 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D9CAF2D192FA6020011F500 /* main.m */; };
 		2D9CAF32192FA6020011F500 /* MJExtensionExample.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2D9CAF31192FA6020011F500 /* MJExtensionExample.1 */; };
+		687B42291B71FB7000D655A2 /* BaseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 687B42281B71FB7000D655A2 /* BaseModel.m */; };
 		89568B751B1B3EAE00B1FACA /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89568B741B1B3EAE00B1FACA /* CoreData.framework */; };
 /* End PBXBuildFile section */
 
@@ -91,6 +92,8 @@
 		2D9CAF2D192FA6020011F500 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2D9CAF30192FA6020011F500 /* MJExtensionExample-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MJExtensionExample-Prefix.pch"; sourceTree = "<group>"; };
 		2D9CAF31192FA6020011F500 /* MJExtensionExample.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = MJExtensionExample.1; sourceTree = "<group>"; };
+		687B42271B71FB7000D655A2 /* BaseModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseModel.h; sourceTree = "<group>"; };
+		687B42281B71FB7000D655A2 /* BaseModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BaseModel.m; sourceTree = "<group>"; };
 		89568B741B1B3EAE00B1FACA /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -157,6 +160,8 @@
 				2D49F3201B2855EC008D5A72 /* Box.m */,
 				2D306F5E1B5A24430069910E /* BaseObject.h */,
 				2D306F5F1B5A24430069910E /* BaseObject.m */,
+				687B42271B71FB7000D655A2 /* BaseModel.h */,
+				687B42281B71FB7000D655A2 /* BaseModel.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -262,6 +267,7 @@
 				2D4A0BFD1B25615700D323A7 /* NSObject+MJKeyValue.m in Sources */,
 				2D306F601B5A24430069910E /* BaseObject.m in Sources */,
 				2D6CAFF91A5AA0BB00E2BA5E /* User.m in Sources */,
+				687B42291B71FB7000D655A2 /* BaseModel.m in Sources */,
 				2D6CAFF61A5AA0BB00E2BA5E /* Ad.m in Sources */,
 				2D6CAFFC1A5AA34800E2BA5E /* Student.m in Sources */,
 				2D4A0BF91B25615700D323A7 /* MJFoundation.m in Sources */,

--- a/MJExtensionExample/MJExtensionExample/Classes/Bag.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/Bag.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface Bag : NSObject
+@interface Bag : BaseModel
 @property (copy, nonatomic) NSString *name;
 @property (assign, nonatomic) double price;
 @end

--- a/MJExtensionExample/MJExtensionExample/Classes/BaseModel.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/BaseModel.h
@@ -1,0 +1,17 @@
+//
+//  BaseModel.h
+//  MJExtensionExample
+//
+//  Created by WeiHan on 8/5/15.
+//  Copyright (c) 2015 小码哥. All rights reserved.
+//
+
+#if USE_CUSTOM_BASECLASS
+
+#import <Foundation/Foundation.h>
+
+@interface BaseModel : NSObject
+
+@end
+
+#endif

--- a/MJExtensionExample/MJExtensionExample/Classes/BaseModel.m
+++ b/MJExtensionExample/MJExtensionExample/Classes/BaseModel.m
@@ -1,0 +1,17 @@
+//
+//  BaseModel.m
+//  MJExtensionExample
+//
+//  Created by WeiHan on 8/5/15.
+//  Copyright (c) 2015 小码哥. All rights reserved.
+//
+
+#if USE_CUSTOM_BASECLASS
+
+#import "BaseModel.h"
+
+@implementation BaseModel
+
+@end
+
+#endif

--- a/MJExtensionExample/MJExtensionExample/Classes/BaseObject.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/BaseObject.h
@@ -8,6 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-@interface BaseObject : NSObject
+@interface BaseObject : BaseModel
 @property (copy, nonatomic) NSString *name;
 @end

--- a/MJExtensionExample/MJExtensionExample/Classes/Book.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/Book.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 @class Box;
 
-@interface Book : NSObject
+@interface Book : BaseModel
 @property (copy, nonatomic) NSString *name;
 @property (copy, nonatomic) NSString *publisher;
 @property (strong, nonatomic) NSDate *publishedTime;

--- a/MJExtensionExample/MJExtensionExample/Classes/Box.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/Box.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface Box : NSObject
+@interface Box : BaseModel
 @property (assign, nonatomic) double weight;
 @property (assign, nonatomic) int size;
 @end

--- a/MJExtensionExample/MJExtensionExample/Classes/Dog.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/Dog.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface Dog : NSObject
+@interface Dog : BaseModel
 @property (copy, nonatomic) NSString *nickName;
 @property (assign, nonatomic) double salePrice;
 @property (assign, nonatomic) double runSpeed;

--- a/MJExtensionExample/MJExtensionExample/Classes/Status.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/Status.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 @class User;
 
-@interface Status : NSObject
+@interface Status : BaseModel
 /** 微博文本内容 */
 @property (copy, nonatomic) NSString *text;
 /** 微博作者 */

--- a/MJExtensionExample/MJExtensionExample/Classes/Student.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/Student.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 @class Bag;
 
-@interface Student : NSObject
+@interface Student : BaseModel
 @property (copy, nonatomic) NSString *ID;
 @property (copy, nonatomic) NSString *nowName;
 @property (copy, nonatomic) NSString *oldName;

--- a/MJExtensionExample/MJExtensionExample/Classes/User.h
+++ b/MJExtensionExample/MJExtensionExample/Classes/User.h
@@ -13,7 +13,7 @@ typedef enum {
     SexFemale
 } Sex;
 
-@interface User : NSObject
+@interface User : BaseModel
 /** 名称 */
 @property (copy, nonatomic) NSString *name;
 /** 头像 */

--- a/MJExtensionExample/MJExtensionExample/MJExtensionExample-Prefix.pch
+++ b/MJExtensionExample/MJExtensionExample/MJExtensionExample-Prefix.pch
@@ -6,5 +6,15 @@
 
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
+
+    #define USE_CUSTOM_BASECLASS    0
+
+#if USE_CUSTOM_BASECLASS
+    #import "BaseModel.h"
+    #define MJExtension_CUSTOM_BASE_CLASS   BaseModel
+#else
+    #define BaseModel NSObject
+#endif
+
     #import "MJExtension.h"
 #endif


### PR DESCRIPTION
@CoderMJLee , you could modify the macro USE_CUSTOM_BASECLASS value from 0 to 1 and test it.

There is a background that we want to integrate MJExtension and make all the model classes inherit our custom class, also I think this is a good extension for you to overwrite the method -[NSObject description] to output some model objects when debugging.