### PR TITLE
保证字典数组转模型数组时，返回的模型数组为NSMutableArray，而不是NSArray

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -237,7 +237,7 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)objectArrayWithKeyValuesArray:(id)keyValuesArray context:(NSManagedObjectContext *)context error:(NSError *__autoreleasing *)error
 {
     // 如果数组里面放的是NSString、NSNumber等数据
-    if ([MJFoundation isClassFromFoundation:self]) return keyValuesArray;
+    if ([MJFoundation isClassFromFoundation:self]) return [NSMutableArray arrayWithArray:keyValuesArray];
     
     // 如果是JSON字符串
     keyValuesArray = [keyValuesArray JSONObject];


### PR DESCRIPTION
当用于转换成模型的字典为immutale时，如果字典中包含数组，数组的元素类型又是NSString*等“foundationClasses”类型时，转化出的数组也为immutale,即使在模型中该数组属性被声明为NSMutableArray*。这种情况会导致在使用数组进行增、删元素操作时的崩溃，所以有必要保证这种情况下的数组也是mutable的。