### PR TITLE
修复小错误

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -465,8 +465,11 @@ static NSNumberFormatter *numberFormatter_;
 - (instancetype)setKeyValues:(id)keyValues error:(NSError **)error
 {
     id value = [self mj_setKeyValues:keyValues];
+    if (error != NULL) {
     *error = [self.class mj_error];
+    }
     return value;
+    
 }
 
 - (instancetype)setKeyValues:(id)keyValues context:(NSManagedObjectContext *)context
@@ -477,7 +480,9 @@ static NSNumberFormatter *numberFormatter_;
 - (instancetype)setKeyValues:(id)keyValues context:(NSManagedObjectContext *)context error:(NSError **)error
 {
     id value = [self mj_setKeyValues:keyValues context:context];
+    if (error != NULL) {
     *error = [self.class mj_error];
+    }
     return value;
 }
 
@@ -494,7 +499,9 @@ static NSNumberFormatter *numberFormatter_;
 - (NSMutableDictionary *)keyValuesWithError:(NSError **)error
 {
     id value = [self mj_keyValues];
+    if (error != NULL) {
     *error = [self.class mj_error];
+    }
     return value;
 }
 
@@ -506,7 +513,9 @@ static NSNumberFormatter *numberFormatter_;
 - (NSMutableDictionary *)keyValuesWithKeys:(NSArray *)keys error:(NSError **)error
 {
     id value = [self mj_keyValuesWithKeys:keys];
+    if (error != NULL) {
     *error = [self.class mj_error];
+    }
     return value;
 }
 
@@ -518,7 +527,9 @@ static NSNumberFormatter *numberFormatter_;
 - (NSMutableDictionary *)keyValuesWithIgnoredKeys:(NSArray *)ignoredKeys error:(NSError **)error
 {
     id value = [self mj_keyValuesWithIgnoredKeys:ignoredKeys];
+    if (error != NULL) {
     *error = [self.class mj_error];
+    }
     return value;
 }
 
@@ -530,7 +541,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)keyValuesArrayWithObjectArray:(NSArray *)objectArray error:(NSError **)error
 {
     id value = [self mj_keyValuesArrayWithObjectArray:objectArray];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -542,7 +555,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)keyValuesArrayWithObjectArray:(NSArray *)objectArray keys:(NSArray *)keys error:(NSError **)error
 {
     id value = [self mj_keyValuesArrayWithObjectArray:objectArray keys:keys];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -554,7 +569,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)keyValuesArrayWithObjectArray:(NSArray *)objectArray ignoredKeys:(NSArray *)ignoredKeys error:(NSError **)error
 {
     id value = [self mj_keyValuesArrayWithObjectArray:objectArray ignoredKeys:ignoredKeys];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -566,7 +583,9 @@ static NSNumberFormatter *numberFormatter_;
 + (instancetype)objectWithKeyValues:(id)keyValues error:(NSError **)error
 {
     id value = [self mj_objectWithKeyValues:keyValues];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -578,7 +597,9 @@ static NSNumberFormatter *numberFormatter_;
 + (instancetype)objectWithKeyValues:(id)keyValues context:(NSManagedObjectContext *)context error:(NSError **)error
 {
     id value = [self mj_objectWithKeyValues:keyValues context:context];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -590,7 +611,9 @@ static NSNumberFormatter *numberFormatter_;
 + (instancetype)objectWithFilename:(NSString *)filename error:(NSError **)error
 {
     id value = [self mj_objectWithFilename:filename];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -602,7 +625,9 @@ static NSNumberFormatter *numberFormatter_;
 + (instancetype)objectWithFile:(NSString *)file error:(NSError **)error
 {
     id value = [self mj_objectWithFile:file];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -614,7 +639,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)objectArrayWithKeyValuesArray:(id)keyValuesArray error:(NSError **)error
 {
     id value = [self mj_objectArrayWithKeyValuesArray:keyValuesArray];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -626,7 +653,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)objectArrayWithKeyValuesArray:(id)keyValuesArray context:(NSManagedObjectContext *)context error:(NSError **)error
 {
     id value = [self mj_objectArrayWithKeyValuesArray:keyValuesArray context:context];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -638,7 +667,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)objectArrayWithFilename:(NSString *)filename error:(NSError **)error
 {
     id value = [self mj_objectArrayWithFilename:filename];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 
@@ -650,7 +681,9 @@ static NSNumberFormatter *numberFormatter_;
 + (NSMutableArray *)objectArrayWithFile:(NSString *)file error:(NSError **)error
 {
     id value = [self mj_objectArrayWithFile:file];
+    if (error != NULL) {
     *error = [self mj_error];
+    }
     return value;
 }
 


### PR DESCRIPTION
静态分析一下会发现在NSObject+MJKeyValue.m文件下的错误提示:Potential null dereference.  According to coding standards in 'Creating and Returning NSError Objects' the parameter may be null,也就是说如果调用方法时error传入的参数为NULL时,会崩溃.需要对error做一个不为NULL的判断.
if (error != NULL) {

    *error = [self mj_error];

    }