### PR TITLE
Model类采用Swift编写的话，NSStringFromClass获取到Class字符串会带上Swift模块名称，例如项目名称为MJE…

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -212,7 +212,8 @@ static NSNumberFormatter *numberFormatter_;
     MJExtensionAssertError([keyValues isKindOfClass:[NSDictionary class]], nil, [self class], @"keyValues参数不是一个字典");
     
     if ([self isSubclassOfClass:[NSManagedObject class]] && context) {
-        return [[NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self) inManagedObjectContext:context] mj_setKeyValues:keyValues context:context];
+        NSString *entityName = [NSStringFromClass(self) componentsSeparatedByString:@"."].lastObject;
+        return [[NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:context] mj_setKeyValues:keyValues context:context];
     }
     return [[[self alloc] init] mj_setKeyValues:keyValues];
 }


### PR DESCRIPTION
Model类采用Swift编写的话，NSStringFromClass获取到Class字符串会带上Swift模块名称，例如项目名称为MJExtensionExample ，model类为User，NSStringFromClass获取到的为MJExtensionExample.User，会导致Crash。