### PR TITLE
修复crash

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -318,7 +318,9 @@ static NSNumberFormatter *numberFormatter_;
             // 1.取出属性值
             id value = [property valueForObject:self];
             if (!value) return;
-            
+            if ([value isKindOfClass:[NSObject class]] && [value superclass] == nil ) {
+                return;
+            }
             // 2.如果是模型属性
             MJPropertyType *type = property.type;
             Class propertyClass = type.typeClass;


### PR DESCRIPTION
修复value 为NSObject 时,[NSJSONSerialization dataWithJSONObject:[self
mj_JSONObject] options:kNilOptions error:nil]; 引发crash的问题
