### PR TITLE
对coreData嵌套解析做处理

### DIFF
--- a/MJExtension/MJFoundation.m
+++ b/MJExtension/MJFoundation.m
@@ -27,7 +27,8 @@ static NSSet *foundationClasses_;
                               [NSArray class],
                               [NSDictionary class],
                               [NSString class],
-                              [NSAttributedString class], nil];
+                              [NSAttributedString class],
+                              [NSSet class],nil];
     }
     return foundationClasses_;
 }

--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -186,6 +186,15 @@ static NSNumberFormatter *numberFormatter_;
             }
             
             // 3.赋值
+            
+            //赋值前先对CoreData进行处理
+            if ([context isKindOfClass:[NSManagedObjectContext class]] &&
+                propertyClass == [NSSet class]                         &&
+                [value isKindOfClass:[NSArray class]])
+            {
+                value = [[NSSet alloc] initWithArray:value];
+            }
+            
             [property setValue:value forObject:self];
         } @catch (NSException *exception) {
             MJExtensionBuildError([self class], exception.reason);


### PR DESCRIPTION
当coreData嵌套时无法解析子类，因为coredata对应为NSSet而非NSArray。