### PR TITLE
Add check ' if the property's value is to be a kind of 'Class' Type ,…

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -125,6 +125,8 @@ static NSNumberFormatter *numberFormatter_;
                 value = [NSMutableString stringWithString:value];
             } else if (propertyClass == [NSMutableData class] && [value isKindOfClass:[NSData class]]) {
                 value = [NSMutableData dataWithData:value];
+            } else if ( class_isMetaClass(object_getClass(value))) {
+                value = NSStringFromClass(value);
             }
             
             if (!type.isFromFoundation && propertyClass) { // 模型属性


### PR DESCRIPTION
原来的 Class 类型没做判断，我上半年用 MJExtention 时候就发现了，于是改了自己用的项目；但是今天下午我新建了一个项目，又用到了 MJExtention ，同样属性里有Class 类型的属性，于是崩溃了。。。隔了大半年，我都忘记这个坑了，于是又排查了好多时间。最后，我认为这是一个需要填的坑，所以我把这个patch搞来了，希望采纳。