### PR TITLE
检查属性值是否是'Class' 类型的属性

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -329,6 +329,8 @@ static NSNumberFormatter *numberFormatter_;
                 value = [NSObject mj_keyValuesArrayWithObjectArray:value];
             } else if (propertyClass == [NSURL class]) {
                 value = [value absoluteString];
+            } else if ( class_isMetaClass(object_getClass(value))) {
+                value = NSStringFromClass(value);
             }
             
             // 4.赋值


### PR DESCRIPTION
Class 类型没做判断。
我上半年用 MJExtention 时候就发现了，于是改了自己用的项目；
但是今天下午我新建了一个项目，又用到了 MJExtention ，同样属性里有Class 类型的属性，于是崩溃了。
隔了大半年，我都忘记这个坑了，于是又排查了好多时间，没想到这个坑还在这里。
为了不让后来者继续浪费这个时间，所以我把这个patch搞来了，希望采纳。