### PR TITLE
Minor typo fixing, example project updates and caches improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ profile
 *.swp
 
 *.xcbkptlist
+
+# AppCode
+**/.idea/

--- a/MJExtension/MJProperty.m
+++ b/MJExtension/MJProperty.m
@@ -12,8 +12,8 @@
 #import <objc/message.h>
 
 @interface MJProperty()
-@property (strong, nonatomic) NSMutableDictionary *propertyKeysDict;
-@property (strong, nonatomic) NSMutableDictionary *objectClassInArrayDict;
+@property (strong, nonatomic) NSCache *propertyKeysCache;
+@property (strong, nonatomic) NSCache *objectClassInArrayCache;
 @end
 
 @implementation MJProperty
@@ -22,8 +22,8 @@
 - (instancetype)init
 {
     if (self = [super init]) {
-        _propertyKeysDict = [NSMutableDictionary dictionary];
-        _objectClassInArrayDict = [NSMutableDictionary dictionary];
+        _propertyKeysCache = [[NSCache alloc] init];
+        _objectClassInArrayCache = [[NSCache alloc] init];
     }
     return self;
 }
@@ -150,21 +150,22 @@
 - (void)setPorpertyKeys:(NSArray *)propertyKeys forClass:(Class)c
 {
     if (propertyKeys.count == 0) return;
-    self.propertyKeysDict[NSStringFromClass(c)] = propertyKeys;
+    [self.propertyKeysCache setObject:propertyKeys forKey:NSStringFromClass(c)];
 }
 - (NSArray *)propertyKeysForClass:(Class)c
 {
-    return self.propertyKeysDict[NSStringFromClass(c)];
+    return [self.propertyKeysCache objectForKey:NSStringFromClass(c)];
 }
 
 /** 模型数组中的模型类型 */
 - (void)setObjectClassInArray:(Class)objectClass forClass:(Class)c
 {
     if (!objectClass) return;
-    self.objectClassInArrayDict[NSStringFromClass(c)] = objectClass;
+    [self.objectClassInArrayCache setObject:objectClass forKey:NSStringFromClass(c)];
 }
 - (Class)objectClassInArrayForClass:(Class)c
 {
-    return self.objectClassInArrayDict[NSStringFromClass(c)];
+    return [self.objectClassInArrayCache objectForKey:NSStringFromClass(c)];
 }
 @end
+

--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -27,31 +27,29 @@ static const char MJCachedPropertiesKey = '\0';
 
 @implementation NSObject (Property)
 
-static NSMutableDictionary *replacedKeyFromPropertyNameDict_;
-static NSMutableDictionary *replacedKeyFromPropertyName121Dict_;
-static NSMutableDictionary *newValueFromOldValueDict_;
-static NSMutableDictionary *objectClassInArrayDict_;
-static NSMutableDictionary *cachedPropertiesDict_;
+static NSCache *replacedKeyFromPropertyNameCache_;
+static NSCache *replacedKeyFromPropertyName121Cache_;
+static NSCache *newValueFromOldValueCache_;
+static NSCache *objectClassInArrayCache_;
+static NSCache *cachedPropertiesCache_;
 
 + (void)load
 {
-    replacedKeyFromPropertyNameDict_ = [NSMutableDictionary dictionary];
-    replacedKeyFromPropertyName121Dict_ = [NSMutableDictionary dictionary];
-    newValueFromOldValueDict_ = [NSMutableDictionary dictionary];
-    objectClassInArrayDict_ = [NSMutableDictionary dictionary];
-    cachedPropertiesDict_ = [NSMutableDictionary dictionary];
+    replacedKeyFromPropertyNameCache_ = [[NSCache alloc] init];
+    replacedKeyFromPropertyName121Cache_ = [[NSCache alloc] init];
+    newValueFromOldValueCache_ = [[NSCache alloc] init];
+    objectClassInArrayCache_ = [[NSCache alloc] init];
+    cachedPropertiesCache_ = [[NSCache alloc] init];
 }
 
-+ (NSMutableDictionary *)dictForKey:(const void *)key
++ (NSCache *)cacheForKey:(const void *)key
 {
-    @synchronized (self) {
-        if (key == &MJReplacedKeyFromPropertyNameKey) return replacedKeyFromPropertyNameDict_;
-        if (key == &MJReplacedKeyFromPropertyName121Key) return replacedKeyFromPropertyName121Dict_;
-        if (key == &MJNewValueFromOldValueKey) return newValueFromOldValueDict_;
-        if (key == &MJObjectClassInArrayKey) return objectClassInArrayDict_;
-        if (key == &MJCachedPropertiesKey) return cachedPropertiesDict_;
-        return nil;
-    }
+    if (key == &MJReplacedKeyFromPropertyNameKey) return replacedKeyFromPropertyNameCache_;
+    if (key == &MJReplacedKeyFromPropertyName121Key) return replacedKeyFromPropertyName121Cache_;
+    if (key == &MJNewValueFromOldValueKey) return newValueFromOldValueCache_;
+    if (key == &MJObjectClassInArrayKey) return objectClassInArrayCache_;
+    if (key == &MJCachedPropertiesKey) return cachedPropertiesCache_;
+    return nil;
 }
 
 #pragma mark - --私有方法--
@@ -150,7 +148,7 @@ static NSMutableDictionary *cachedPropertiesDict_;
 #pragma mark - 公共方法
 + (NSMutableArray *)properties
 {
-    NSMutableArray *cachedProperties = [self dictForKey:&MJCachedPropertiesKey][NSStringFromClass(self)];
+    NSMutableArray *cachedProperties = [[self cacheForKey:&MJCachedPropertiesKey] objectForKey:NSStringFromClass(self)];
     
     if (cachedProperties == nil) {
         cachedProperties = [NSMutableArray array];
@@ -175,7 +173,7 @@ static NSMutableDictionary *cachedPropertiesDict_;
             free(properties);
         }];
         
-        [self dictForKey:&MJCachedPropertiesKey][NSStringFromClass(self)] = cachedProperties;
+        [[self cacheForKey:&MJCachedPropertiesKey] setObject:cachedProperties forKey:NSStringFromClass(self)];
     }
     
     return cachedProperties;
@@ -214,7 +212,7 @@ static NSMutableDictionary *cachedPropertiesDict_;
 {
     [self mj_setupBlockReturnValue:objectClassInArray key:&MJObjectClassInArrayKey];
     
-    [[self dictForKey:&MJCachedPropertiesKey] removeAllObjects];
+    [[self cacheForKey:&MJCachedPropertiesKey] removeAllObjects];
 }
 
 #pragma mark - key配置
@@ -222,14 +220,14 @@ static NSMutableDictionary *cachedPropertiesDict_;
 {
     [self mj_setupBlockReturnValue:replacedKeyFromPropertyName key:&MJReplacedKeyFromPropertyNameKey];
     
-    [[self dictForKey:&MJCachedPropertiesKey] removeAllObjects];
+    [[self cacheForKey:&MJCachedPropertiesKey] removeAllObjects];
 }
 
 + (void)mj_setupReplacedKeyFromPropertyName121:(MJReplacedKeyFromPropertyName121)replacedKeyFromPropertyName121
 {
     objc_setAssociatedObject(self, &MJReplacedKeyFromPropertyName121Key, replacedKeyFromPropertyName121, OBJC_ASSOCIATION_COPY_NONATOMIC);
     
-    [[self dictForKey:&MJCachedPropertiesKey] removeAllObjects];
+    [[self cacheForKey:&MJCachedPropertiesKey] removeAllObjects];
 }
 @end
 
@@ -266,3 +264,5 @@ static NSMutableDictionary *cachedPropertiesDict_;
 @end
 
 #pragma clang diagnostic pop
+
+

--- a/MJExtensionExample/main.h
+++ b/MJExtensionExample/main.h
@@ -11,19 +11,19 @@
 
 
 /** 函数的声明（只用于此示例程序，仅仅是为了演示框架的使用） */
-void keyValues2object();
-void keyValues2object1();
-void keyValues2object2();
-void keyValues2object3();
-void keyValues2object4();
-void keyValuesArray2objectArray();
-void object2keyValues();
-void objectArray2keyValuesArray();
-void coreData();
-void coding();
-void replacedKeyFromPropertyName121();
-void newValueFromOldValue();
-void logAllProperties();
-void execute(void (*fn)(), NSString *comment);
+void keyValues2object(void);
+void keyValues2object1(void);
+void keyValues2object2(void);
+void keyValues2object3(void);
+void keyValues2object4(void);
+void keyValuesArray2objectArray(void);
+void object2keyValues(void);
+void objectArray2keyValuesArray(void);
+void coreData(void);
+void coding(void);
+void replacedKeyFromPropertyName121(void);
+void newValueFromOldValue(void);
+void logAllProperties(void);
+void execute(void (*fn)(void), NSString *comment);
 
 #endif

--- a/MJExtensionExample/main.m
+++ b/MJExtensionExample/main.m
@@ -425,7 +425,7 @@ void logAllProperties()
     MJExtensionLog(@"%@", user);
 }
 
-void execute(void (*fn)(), NSString *comment)
+void execute(void (*fn)(void), NSString *comment)
 {
     MJExtensionLog(@"[******************%@******************开始]", comment);
     fn();

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ NSLog(@"name=%@, publisher=%@, publishedTime=%@", book.name, book.publisher, boo
 ```
 
 ### <a id="More_use_cases"></a> More use cases【更多用法】
-- Please reference to `NSObject+MJKeyValue.h` and `NSObject+MJCoding.h`
+- Please refer to `NSObject+MJKeyValue.h` and `NSObject+MJCoding.h`
 
 
 ## 期待


### PR DESCRIPTION
Hi,

I **fixed another typo in README.md** which I dismissed yesterday. And **the example project has been updated for the function pointer declarations to dismiss warnings** since XCode 9 has a stronger grammar check. 

I also noticed there are some typos in the description of the repository. But I don't have access to revise them. Nor I can submit a PR to fix them. Please fix those typos on your own by editing the repository description:

![image](https://user-images.githubusercontent.com/8213501/34316570-2ea548b6-e7d4-11e7-9bdb-b0387ce7bd0c.png)

Another update is that I **changed all of the caches from `NSMutableDictionary` to `NSCache`**. `NSCache` has quiet a lot benefits when dealing with caches. For example, cached objects would be evicted automatically if the memory is running low. If a project contains too many Models, this framework would end up holding a lot of memory which is not that responsible to users. And it is thread-safe, that's why I removed `@synchronized (self) {}`. You can checkout the formal documentation about `NSCache` at https://developer.apple.com/documentation/foundation/nscache.

Could you spare some time to review this PR? Thanks.
