### PR TITLE
json中如果对应value是double类型，增加对NSDecimalNumber属性解析的支持

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2015 MJExtension (https://github.com/CoderMJLee/MJExtension)
+Copyright (c) 2013-2018 MJExtension (https://github.com/CoderMJLee/MJExtension)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -177,17 +177,15 @@ static NSNumberFormatter *numberFormatter_;
                             }
                         }
                     }
-                }else if ([value isKindOfClass:[NSNumber class]] && type.typeClass == [NSDecimalNumber class]){
+                } else if ([value isKindOfClass:[NSNumber class]] && propertyClass == [NSDecimalNumber class]){
                     // 过滤 NSDecimalNumber类型
-                    if ([value isKindOfClass:[NSDecimalNumber class]]) {
-                        
-                    } else {
-                        value = [NSDecimalNumber decimalNumberWithDecimal:[((NSNumber *)value) decimalValue]];
+                    if (![value isKindOfClass:[NSDecimalNumber class]]) {
+                         value = [NSDecimalNumber decimalNumberWithDecimal:[((NSNumber *)value) decimalValue]];
                     }
                 }
                 
                 // value和property类型不匹配
-                if (propertyClass && ![value isKindOfClass:propertyClass] && propertyClass != [NSDecimalNumber class]) {
+                if (propertyClass && ![value isKindOfClass:propertyClass]){
                     value = nil;
                 }
             }

--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -177,10 +177,17 @@ static NSNumberFormatter *numberFormatter_;
                             }
                         }
                     }
+                }else if ([value isKindOfClass:[NSNumber class]] && type.typeClass == [NSDecimalNumber class]){
+                    // 过滤 NSDecimalNumber类型
+                    if ([value isKindOfClass:[NSDecimalNumber class]]) {
+                        
+                    } else {
+                        value = [NSDecimalNumber decimalNumberWithDecimal:[((NSNumber *)value) decimalValue]];
+                    }
                 }
                 
                 // value和property类型不匹配
-                if (propertyClass && ![value isKindOfClass:propertyClass]) {
+                if (propertyClass && ![value isKindOfClass:propertyClass] && propertyClass != [NSDecimalNumber class]) {
                     value = nil;
                 }
             }

--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -185,7 +185,7 @@ static NSNumberFormatter *numberFormatter_;
                 }
                 
                 // value和property类型不匹配
-                if (propertyClass && ![value isKindOfClass:propertyClass]){
+                if (propertyClass && ![value isKindOfClass:propertyClass]) {
                     value = nil;
                 }
             }


### PR DESCRIPTION
在我们实际开发的过程中，有很多应用场景是Model中的某些字段需要用到`NSDecimalNumber `来做精确计算，但是服务器如果返回的json中对应的value不是字符串类型，导致解析出来的数据`NSDecimalNumber `字段为nil[#625](https://github.com/CoderMJLee/MJExtension/issues/625)。参考了`YYModel`、`jsonmodel`对于`NSDecimalNumber `的处理方式，json中如果对应value是double类型，添加`MJExtension`对`NSDecimalNumber`属性解析的支持。