### PR TITLE
过滤 NSObject 协议中`hash`, `superclass`, `description`, `debugDescription`

### DIFF
--- a/MJExtension/MJFoundation.h
+++ b/MJExtension/MJFoundation.h
@@ -9,5 +9,8 @@
 #import <Foundation/Foundation.h>
 
 @interface MJFoundation : NSObject
+
 + (BOOL)isClassFromFoundation:(Class)c;
++ (BOOL)isFromNSObjectProtocolProperty:(NSString *)propertyName;
+
 @end

--- a/MJExtension/MJFoundation.m
+++ b/MJExtension/MJFoundation.m
@@ -41,4 +41,23 @@
     }];
     return result;
 }
+
++ (BOOL)isFromNSObjectProtocolProperty:(NSString *)propertyName
+{
+    if (!propertyName) return NO;
+    
+    static NSSet *objectProtocolPropertyNames;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        // 如果遵守<NSObject>，过滤`hash`, `superclass`, `description`, `debugDescription`
+        objectProtocolPropertyNames = [NSSet setWithObjects:
+                                       NSStringFromSelector(@selector(hash)),
+                                       NSStringFromSelector(@selector(superclass)),
+                                       NSStringFromSelector(@selector(description)),
+                                       NSStringFromSelector(@selector(debugDescription)),
+                                       nil];
+    });
+    return [objectProtocolPropertyNames containsObject:propertyName];
+}
+
 @end

--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -166,6 +166,9 @@ static const char MJCachedPropertiesKey = '\0';
                     MJProperty *property = [MJProperty cachedPropertyWithProperty:properties[i]];
                     // 过滤掉Foundation框架类里面的属性
                     if ([MJFoundation isClassFromFoundation:property.srcClass]) continue;
+                    // 过滤掉`hash`, `superclass`, `description`, `debugDescription`
+                    if ([MJFoundation isFromNSObjectProtocolProperty:property.name]) continue;
+                    
                     property.srcClass = c;
                     [property setOriginKey:[self propertyKey:property.name] forClass:self];
                     [property setObjectClassInArray:[self propertyObjectClassInArray:property.name] forClass:self];


### PR DESCRIPTION
目前如果声明的Model，遵循了某个协议，在进行字典转模型的时候，会多了`<NSObject>`的4个属性 ：

`hash`, `superclass`, `description`, `debugDescription`

从而解析失败，导致Crash。这个PR是在获取属性列表时过滤上述情况，避免Crash！