### PR TITLE
Modifying lock to improve code performance

### DIFF
--- a/MJExtension/MJExtensionConst.h
+++ b/MJExtension/MJExtensionConst.h
@@ -5,12 +5,23 @@
 #import <Foundation/Foundation.h>
 
 #ifndef MJ_LOCK
-#define MJ_LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER)
+#define MJ_LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #endif
 
 #ifndef MJ_UNLOCK
-#define MJ_UNLOCK(lock) dispatch_semaphore_signal(lock)
+#define MJ_UNLOCK(lock) dispatch_semaphore_signal(lock);
 #endif
+
+// 信号量
+#define MJExtensionSemaphoreCreate \
+static dispatch_semaphore_t signalSemaphore; \
+static dispatch_once_t onceTokenSemaphore; \
+dispatch_once(&onceTokenSemaphore, ^{ \
+    signalSemaphore = dispatch_semaphore_create(1); \
+});
+
+#define MJExtensionSemaphoreWait MJ_LOCK(signalSemaphore)
+#define MJExtensionSemaphoreSignal MJ_UNLOCK(signalSemaphore)
 
 // 过期
 #define MJExtensionDeprecated(instead) NS_DEPRECATED(2_0, 2_0, 2_0, 2_0, instead)

--- a/MJExtension/MJExtensionConst.h
+++ b/MJExtension/MJExtensionConst.h
@@ -4,19 +4,13 @@
 
 #import <Foundation/Foundation.h>
 
-// 信号量
-#define MJExtensionSemaphoreCreate \
-static dispatch_semaphore_t signalSemaphore; \
-static dispatch_once_t onceTokenSemaphore; \
-dispatch_once(&onceTokenSemaphore, ^{ \
-    signalSemaphore = dispatch_semaphore_create(1); \
-});
+#ifndef MJ_LOCK
+#define MJ_LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER)
+#endif
 
-#define MJExtensionSemaphoreWait \
-dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
-
-#define MJExtensionSemaphoreSignal \
-dispatch_semaphore_signal(signalSemaphore);
+#ifndef MJ_UNLOCK
+#define MJ_UNLOCK(lock) dispatch_semaphore_signal(lock)
+#endif
 
 // 过期
 #define MJExtensionDeprecated(instead) NS_DEPRECATED(2_0, 2_0, 2_0, 2_0, instead)

--- a/MJExtension/MJPropertyType.m
+++ b/MJExtension/MJPropertyType.m
@@ -23,15 +23,12 @@
         types = [NSMutableDictionary dictionary];
     });
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
     MJPropertyType *type = types[code];
     if (type == nil) {
         type = [[self alloc] init];
         type.code = code;
         types[code] = type;
     }
-    MJExtensionSemaphoreSignal
     return type;
 }
 

--- a/MJExtension/NSObject+MJClass.m
+++ b/MJExtension/NSObject+MJClass.m
@@ -12,13 +12,6 @@
 #import "MJFoundation.h"
 #import <objc/runtime.h>
 
-#define MJClassSemaphoreCreate \
-static dispatch_semaphore_t _classSemaphore; \
-static dispatch_once_t onceTokenSemaphore; \
-dispatch_once(&onceTokenSemaphore, ^{ \
-    _classSemaphore = dispatch_semaphore_create(1); \
-});
-
 static const char MJAllowedPropertyNamesKey = '\0';
 static const char MJIgnoredPropertyNamesKey = '\0';
 static const char MJAllowedCodingPropertyNamesKey = '\0';
@@ -146,16 +139,16 @@ static const char MJIgnoredCodingPropertyNamesKey = '\0';
     }
     
     // 清空数据
-    MJClassSemaphoreCreate
-    MJ_LOCK(_classSemaphore);
+    MJExtensionSemaphoreCreate
+    MJExtensionSemaphoreWait
     [[self classDictForKey:key] removeAllObjects];
-    MJ_UNLOCK(_classSemaphore);
+    MJExtensionSemaphoreSignal
 }
 
 + (NSMutableArray *)mj_totalObjectsWithSelector:(SEL)selector key:(const char *)key
 {
-    MJClassSemaphoreCreate
-    MJ_LOCK(_classSemaphore);
+    MJExtensionSemaphoreCreate
+    MJExtensionSemaphoreWait
     NSMutableArray *array = [self classDictForKey:key][NSStringFromClass(self)];
     if (array == nil) {
         // 创建、存储
@@ -176,7 +169,7 @@ static const char MJIgnoredCodingPropertyNamesKey = '\0';
             [array addObjectsFromArray:subArray];
         }];
     }
-    MJ_UNLOCK(_classSemaphore);
+    MJExtensionSemaphoreSignal
     return array;
 }
 @end

--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -18,6 +18,13 @@
 #pragma clang diagnostic ignored "-Wundeclared-selector"
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 
+#define MJPropertySemaphoreCreate \
+static dispatch_semaphore_t _propertySemaphore; \
+static dispatch_once_t onceTokenSemaphore; \
+dispatch_once(&onceTokenSemaphore, ^{ \
+    _propertySemaphore = dispatch_semaphore_create(1); \
+});
+
 static const char MJReplacedKeyFromPropertyNameKey = '\0';
 static const char MJReplacedKeyFromPropertyName121Key = '\0';
 static const char MJNewValueFromOldValueKey = '\0';
@@ -135,10 +142,10 @@ static const char MJCachedPropertiesKey = '\0';
 + (void)mj_enumerateProperties:(MJPropertiesEnumeration)enumeration
 {
     // 获得成员变量
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    MJPropertySemaphoreCreate
+    MJ_LOCK(_propertySemaphore);
     NSArray *cachedProperties = [self properties];
-    MJExtensionSemaphoreSignal
+    MJ_UNLOCK(_propertySemaphore);
     // 遍历成员变量
     BOOL stop = NO;
     for (MJProperty *property in cachedProperties) {
@@ -219,10 +226,10 @@ static const char MJCachedPropertiesKey = '\0';
 {
     [self mj_setupBlockReturnValue:objectClassInArray key:&MJObjectClassInArrayKey];
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    MJPropertySemaphoreCreate
+    MJ_LOCK(_propertySemaphore);
     [[self propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    MJ_UNLOCK(_propertySemaphore);
 }
 
 #pragma mark - key配置
@@ -230,20 +237,20 @@ static const char MJCachedPropertiesKey = '\0';
 {
     [self mj_setupBlockReturnValue:replacedKeyFromPropertyName key:&MJReplacedKeyFromPropertyNameKey];
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    MJPropertySemaphoreCreate
+    MJ_LOCK(_propertySemaphore);
     [[self propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    MJ_UNLOCK(_propertySemaphore);
 }
 
 + (void)mj_setupReplacedKeyFromPropertyName121:(MJReplacedKeyFromPropertyName121)replacedKeyFromPropertyName121
 {
     objc_setAssociatedObject(self, &MJReplacedKeyFromPropertyName121Key, replacedKeyFromPropertyName121, OBJC_ASSOCIATION_COPY_NONATOMIC);
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    MJPropertySemaphoreCreate
+    MJ_LOCK(_propertySemaphore);
     [[self propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    MJ_UNLOCK(_propertySemaphore);
 }
 @end
 

--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -18,13 +18,6 @@
 #pragma clang diagnostic ignored "-Wundeclared-selector"
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 
-#define MJPropertySemaphoreCreate \
-static dispatch_semaphore_t _propertySemaphore; \
-static dispatch_once_t onceTokenSemaphore; \
-dispatch_once(&onceTokenSemaphore, ^{ \
-    _propertySemaphore = dispatch_semaphore_create(1); \
-});
-
 static const char MJReplacedKeyFromPropertyNameKey = '\0';
 static const char MJReplacedKeyFromPropertyName121Key = '\0';
 static const char MJNewValueFromOldValueKey = '\0';
@@ -142,10 +135,10 @@ static const char MJCachedPropertiesKey = '\0';
 + (void)mj_enumerateProperties:(MJPropertiesEnumeration)enumeration
 {
     // 获得成员变量
-    MJPropertySemaphoreCreate
-    MJ_LOCK(_propertySemaphore);
+    MJExtensionSemaphoreCreate
+    MJExtensionSemaphoreWait
     NSArray *cachedProperties = [self properties];
-    MJ_UNLOCK(_propertySemaphore);
+    MJExtensionSemaphoreSignal
     // 遍历成员变量
     BOOL stop = NO;
     for (MJProperty *property in cachedProperties) {
@@ -226,10 +219,10 @@ static const char MJCachedPropertiesKey = '\0';
 {
     [self mj_setupBlockReturnValue:objectClassInArray key:&MJObjectClassInArrayKey];
     
-    MJPropertySemaphoreCreate
-    MJ_LOCK(_propertySemaphore);
+    MJExtensionSemaphoreCreate
+    MJExtensionSemaphoreWait
     [[self propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJ_UNLOCK(_propertySemaphore);
+    MJExtensionSemaphoreSignal
 }
 
 #pragma mark - key配置
@@ -237,20 +230,20 @@ static const char MJCachedPropertiesKey = '\0';
 {
     [self mj_setupBlockReturnValue:replacedKeyFromPropertyName key:&MJReplacedKeyFromPropertyNameKey];
     
-    MJPropertySemaphoreCreate
-    MJ_LOCK(_propertySemaphore);
+    MJExtensionSemaphoreCreate
+    MJExtensionSemaphoreWait
     [[self propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJ_UNLOCK(_propertySemaphore);
+    MJExtensionSemaphoreSignal
 }
 
 + (void)mj_setupReplacedKeyFromPropertyName121:(MJReplacedKeyFromPropertyName121)replacedKeyFromPropertyName121
 {
     objc_setAssociatedObject(self, &MJReplacedKeyFromPropertyName121Key, replacedKeyFromPropertyName121, OBJC_ASSOCIATION_COPY_NONATOMIC);
     
-    MJPropertySemaphoreCreate
-    MJ_LOCK(_propertySemaphore);
+    MJExtensionSemaphoreCreate
+    MJExtensionSemaphoreWait
     [[self propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJ_UNLOCK(_propertySemaphore);
+    MJExtensionSemaphoreSignal
 }
 @end
 


### PR DESCRIPTION
1. 修复`MJProperty`类中可变容器getter方法没有加锁引发线程安全问题的bug [https://github.com/CoderMJLee/MJExtension/issues/660#issuecomment-469505529](https://github.com/CoderMJLee/MJExtension/issues/660#issuecomment-469505529) .

2. 当前MJExtension使用全局的一把锁，影响效率： 
   a->  针对全局静态容器，为每一个容器新建一把静态全局锁(总共两把静态锁，之前是一把静态锁)。
   b->  对于`MJProperty`中可变容器的锁跟随`MJProperty`类的生命周期一起，不需要使用全局的锁。

3.  下面方法本来在`[self properties]`就加锁了，属于单一线程执行，没有必要再加锁：
```Objc
[MJProperty cachedPropertyWithProperty:]
[MJPropertyType cachedTypeWithCode:]
```