### PR TITLE
fix iOS13-beta系统上NSNull执行mj_objectWithKeyValues触发的crash

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -306,6 +306,9 @@ static NSNumberFormatter *numberFormatter_;
 
 - (NSMutableDictionary *)mj_keyValuesWithKeys:(NSArray *)keys ignoredKeys:(NSArray *)ignoredKeys
 {
+    if ([self isKindOfClass:[NSNull class]]) {
+        return [NSMutableDictionary dictionary];
+    }
     // 如果自己不是模型类, 那就返回自己
     MJExtensionAssertError(![MJFoundation isClassFromFoundation:[self class]], (NSMutableDictionary *)self, [self class], @"不是自定义的模型类")
     


### PR DESCRIPTION
Crash Demo:https://github.com/Yasic/MJExtensionCrashDemoForiOS13Beta
Issue: https://github.com/CoderMJLee/MJExtension/issues/692