### PR TITLE
Add support for SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,17 +4,19 @@ import PackageDescription
 
 let package = Package(
     name: "MJExtension",
-     platforms: [
+    platforms: [
         .macOS(.v10_10),
         .iOS(.v8)
     ],
     products: [
-       .library(name: "MJExtension", targets: ["MJExtension"])
-   ],
-   targets: [
+       .library(
+        name: "MJExtension",
+        targets: ["MJExtension"])
+    ],
+    targets: [
        .target(
            name: "MJExtension",
            path: "MJExtension"
        )
-   ]
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MJExtension",
+     platforms: [
+        .macOS(.v10_10),
+        .iOS(.v8)
+    ],
+    products: [
+       .library(name: "MJExtension", targets: ["MJExtension"])
+   ],
+   targets: [
+       .target(
+           name: "MJExtension",
+           path: "MJExtension"
+       )
+   ]
+)


### PR DESCRIPTION

Xcode 11 introduce the support for Swift Package Manager (SwiftPM).  It supports for not only Swift files, but also the C/C++ files.

So, since MJExtension is written in Objective-C, it should be supported. 

The `Package.swift` is like the `Podfile`, a rule to define the compile and target. See the full documentation for [Package.swift syntax](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md)



