### PR TITLE
Add ability to validate the converted model object

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.h
+++ b/MJExtension/NSObject+MJKeyValue.h
@@ -57,6 +57,12 @@
 - (id)mj_newValueFromOldValue:(id)oldValue property:(MJProperty *)property;
 
 /**
+ * Validates the converted model object.
+ * 校验从字典转换后的模型对象。
+ */
++ (BOOL)mj_validateConvertedObject:(id)object;
+
+/**
  *  当字典转模型完毕时调用
  */
 - (void)mj_keyValuesDidFinishConvertingToObject;


### PR DESCRIPTION
这个 PR 尝试给字典转换后的模型对象增加校验接口。

如果字典数据不合法， `+mj_objectWithKeyValues:` 返回的模型对象可能是一个「空」对象 `[[self alloc] init]` 或者缺少某些属性值或者某些属性值不合法等等，继而会导致调用方代码出问题，比如使用了一个 userID 为 nil 的 User 对象。

我刚刚开始用 MJExtension ，不知道大家是怎么做校验的，网上也没搜到别人的方案。我是在 `+mj_objectWithKeyValues:context:` 这个方法里，返回结果前进行校验。
我没细看 MJExtension 的代码，不知道这样修改会不会引出其他问题，还望大佬指正。

本来是做了个包自己用的，https://github.com/ElfSundae/MJExtensionValidation 刚想也许这个功能可以加到主版本里。

使用示例：在模型中实现 `+mj_validateConvertedObject` 接口即可：

```
+ (BOOL)mj_validateConvertedObject:(MJUser *)user
{
    return !!user.name.length;
}
```

上面的示例中，如果转换后的 user 对象的  name 属性为 nil 或空字符串，就会校验失败，`objectWithKeyValues` 等方法会返回 `nil` 。

该校验接口会作用到所有字典转模型的方法里，诸如 `objectWithKeyValues`, `objectWithFile`, `objectArrayWithKeyValuesArray`, `objectArrayWithFile` 等。
