### PR TITLE
Fix number formatter transform bug

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -53,11 +53,8 @@ static const char MJReferenceReplacedKeyWhenCreatingKeyValuesKey = '\0';
 }
 
 #pragma mark - --常用的对象--
-static NSNumberFormatter *numberFormatter_;
 + (void)load
 {
-    numberFormatter_ = [[NSNumberFormatter alloc] init];
-    
     // 默认设置
     [self mj_referenceReplacedKeyWhenCreatingKeyValues:YES];
 }
@@ -162,7 +159,7 @@ static NSNumberFormatter *numberFormatter_;
                         if (type.typeClass == [NSDecimalNumber class]) {
                             value = [NSDecimalNumber decimalNumberWithString:oldValue];
                         } else {
-                            value = [numberFormatter_ numberFromString:oldValue];
+                            value = @([NSDecimalNumber decimalNumberWithString:oldValue].doubleValue);
                         }
                         
                         // 如果是BOOL

--- a/MJExtensionDemo.xcodeproj/project.pbxproj
+++ b/MJExtensionDemo.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = MJExtensionDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -643,6 +644,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = MJExtensionDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MJExtensionTests/MJExtensionTests.m
+++ b/MJExtensionTests/MJExtensionTests.m
@@ -34,7 +34,10 @@
                            @"height" : @1.55,
                            @"money" : @"100.9",
                            @"sex" : @(SexFemale),
-                           @"gay" : @"1"
+                           @"gay" : @"1",
+                           @"speed" : @"120.5",
+                           @"identifier" : @"3443623624362",
+                           @"price" : @"20.3",
                            //  @"gay" : @"NO"
                            //  @"gay" : @"true"
                            };
@@ -50,6 +53,9 @@
     XCTAssert(user.money.doubleValue == 100.9);
     XCTAssert(user.sex == SexFemale);
     XCTAssert(user.gay == YES);
+    XCTAssert(user.speed == 120);
+    XCTAssert(user.identifier == 3443623624362);
+    XCTAssert(user.price == 20.3);
 }
 
 #pragma mark JSON字符串 -> 模型

--- a/MJExtensionTests/Model/MJUser.h
+++ b/MJExtensionTests/Model/MJUser.h
@@ -28,4 +28,11 @@ typedef enum {
 @property (assign, nonatomic) Sex sex;
 /** 同性恋 */
 @property (assign, nonatomic, getter=isGay) BOOL gay;
+/** 速度 */
+@property (assign, nonatomic) NSInteger speed;
+/** 标识 */
+@property (assign, nonatomic) long long identifier;
+/** 价格 */
+@property (assign, nonatomic) double price;
+
 @end


### PR DESCRIPTION
In Russian language Environmental ：

 When using `numberFromString:`  for string value @"20.3"  transform to double value , the result is nil,
This pr fix it .