### PR TITLE
Callback converted keyValues as NSMutableDictionary instead of NSDictionary

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.h
+++ b/MJExtension/NSObject+MJKeyValue.h
@@ -71,7 +71,7 @@
  *  当模型转字典完毕时调用
  */
 - (void)mj_objectDidFinishConvertingToKeyValues MJExtensionDeprecated("请使用`mj_objectDidConvertToKeyValues:`替代");
-- (void)mj_objectDidConvertToKeyValues:(NSDictionary *)keyValues;
+- (void)mj_objectDidConvertToKeyValues:(NSMutableDictionary *)keyValues;
 
 @end
 


### PR DESCRIPTION
模型转字典完后，回调 `NSMutableDictionary` 类型的 keyValues ，方便修改转换后的字典，要不然每次都得强转。