### PR TITLE
修复crash

### DIFF
--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -130,6 +130,9 @@ static const char MJCachedPropertiesKey = '\0';
     // 遍历成员变量
     BOOL stop = NO;
     for (MJProperty *property in cachedProperties) {
+        if (!property.type.isFromFoundation) { // 非Fundation的key，直接舍弃
+            continue;
+        }
         enumeration(property, &stop);
         if (stop) break;
     }


### PR DESCRIPTION
fix 模型中有非Fundation的property导致的crash
[MJExtesionCrashDemo.zip](https://github.com/CoderMJLee/MJExtension/files/5390629/MJExtesionCrashDemo.zip)
