### PR TITLE
Fix `valueForObject` crash in 32bit devices

### DIFF
--- a/MJExtension/MJProperty.m
+++ b/MJExtension/MJProperty.m
@@ -81,7 +81,7 @@
     /** https://github.com/CoderMJLee/MJExtension/issues/545 */
     // 32 bit device OR 32 bit Simulator
 #if defined(__arm__) || (TARGET_OS_SIMULATOR && !__LP64__)
-    if (self.type.isBoolType) {
+    if (self.type.isBoolType && [value respondsToSelector:@selector(boolValue)]) {
         value = @([(NSNumber *)value boolValue]);
     }
 #endif


### PR DESCRIPTION

iPhone 5   iOS 10  

```objc

0 | libobjc.A.dylib | _lookUpImpOrForward()
1 | libobjc.A.dylib | __class_lookupMethodAndLoadCache3()
2 | libobjc.A.dylib | __objc_msgSend_uncached()
3 | myApp | -[MJProperty valueForObject:](MJProperty.m)
4 | myApp | __57-[NSObject(MJKeyValue) mj_keyValuesWithKeys:ignoredKeys:]_block_invoke(NSObject+MJKeyValue.m:0)
5 | myApp | +[NSObject(Property) mj_enumerateProperties:](NSObject+MJProperty.m:151)
6 | myApp | -[NSObject(MJKeyValue) mj_keyValuesWithKeys:ignoredKeys:](NSObject+MJKeyValue.m:396)
7 | myApp | __57-[NSObject(MJKeyValue) mj_keyValuesWithKeys:ignoredKeys:]_block_invoke(NSObject+MJKeyValue.m:332)
8 | myApp | +[NSObject(Property) mj_enumerateProperties:](NSObject+MJProperty.m:151)
9 | myApp | -[NSObject(MJKeyValue) mj_keyValuesWithKeys:ignoredKeys:](NSObject+MJKeyValue.m:396)
10 | myApp | __57-[NSObject(MJKeyValue) mj_keyValuesWithKeys:ignoredKeys:]_block_invoke(NSObject+MJKeyValue.m:332)
11 | myApp | +[NSObject(Property) mj_enumerateProperties:](NSObject+MJProperty.m:151)
12 | myApp | -[NSObject(MJKeyValue) mj_keyValuesWithKeys:ignoredKeys:](NSObject+MJKeyValue.m:396)


```