### PR TITLE
修复 model 中如果遵守的协议存在属性 crash 的case

### DIFF
--- a/MJExtension/MJProperty.m
+++ b/MJExtension/MJProperty.m
@@ -75,7 +75,12 @@
 {
     if (self.type.KVCDisabled) return [NSNull null];
     
-    id value = [object valueForKey:self.name];
+    id value;
+    @try {
+        value = [object valueForKey:self.name];
+    } @catch (NSException *exception) {
+        NSLog(@"[MJExtension]: crash %@", exception);
+    }
     
     // 32位BOOL类型转换json后成Int类型
     /** https://github.com/CoderMJLee/MJExtension/issues/545 */
@@ -95,7 +100,11 @@
 - (void)setValue:(id)value forObject:(id)object
 {
     if (self.type.KVCDisabled || value == nil) return;
-    [object setValue:value forKey:self.name];
+    @try {
+        [object setValue:value forKey:self.name];
+    } @catch (NSException *exception) {
+        NSLog(@"[MJExtension]: crash %@", exception);
+    }
 }
 
 /**

--- a/MJExtension/MJProperty.m
+++ b/MJExtension/MJProperty.m
@@ -75,12 +75,7 @@
 {
     if (self.type.KVCDisabled) return [NSNull null];
     
-    id value;
-    @try {
-        value = [object valueForKey:self.name];
-    } @catch (NSException *exception) {
-        NSLog(@"[MJExtension]: crash %@", exception);
-    }
+    id value = [object valueForKey:self.name];
     
     // 32位BOOL类型转换json后成Int类型
     /** https://github.com/CoderMJLee/MJExtension/issues/545 */
@@ -100,11 +95,7 @@
 - (void)setValue:(id)value forObject:(id)object
 {
     if (self.type.KVCDisabled || value == nil) return;
-    @try {
-        [object setValue:value forKey:self.name];
-    } @catch (NSException *exception) {
-        NSLog(@"[MJExtension]: crash %@", exception);
-    }
+    [object setValue:value forKey:self.name];
 }
 
 /**

--- a/MJExtensionTests/MJExtensionTests.m
+++ b/MJExtensionTests/MJExtensionTests.m
@@ -525,4 +525,20 @@
     
     MJExtensionLog(@"%@", user);
 }
+
+- (void)testProtocolProperty {
+    MJBox *box = [[MJBox alloc] init];
+    box.weight = 100.1;
+    box.size = 10;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:box];
+    XCTAssertTrue(data != nil);
+    MJBox *newBox = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#pragma clang diagnostic pop
+    
+    XCTAssertEqual(newBox.weight, 100.1);
+    XCTAssertEqual(newBox.size, 10);
+}
+
 @end

--- a/MJExtensionTests/Model/MJBox.h
+++ b/MJExtensionTests/Model/MJBox.h
@@ -8,7 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-@interface MJBox : NSObject
+@protocol MJBoxDelegate <NSObject>
+
+@optional
+@property (copy, nonatomic) NSString *name;
+@end
+
+@interface MJBox : NSObject <MJBoxDelegate>
 @property (assign, nonatomic) double weight;
 @property (assign, nonatomic) int size;
 @end


### PR DESCRIPTION
`protocol_copyPropertyList2(Protocol * _Nonnull proto,
                           unsigned int * _Nullable outCount,
                           BOOL isRequiredProperty, BOOL isInstanceProperty)`


该API 并不能获取到 optional/required properties 同时依赖 iOS10，遂选用 `protocol_copyPropertyList()`