### PR TITLE
修复 static 作用域问题导致的多线程下 model.mj_keyValues 和 [model mj_setupReplacedKeyFromPropertyName] 崩溃的问题

### DIFF
--- a/MJExtension/MJExtensionConst.h
+++ b/MJExtension/MJExtensionConst.h
@@ -12,16 +12,6 @@
 #define MJ_UNLOCK(lock) dispatch_semaphore_signal(lock);
 #endif
 
-// 信号量
-#define MJExtensionSemaphoreCreate \
-static dispatch_semaphore_t signalSemaphore; \
-static dispatch_once_t onceTokenSemaphore; \
-dispatch_once(&onceTokenSemaphore, ^{ \
-    signalSemaphore = dispatch_semaphore_create(1); \
-});
-
-#define MJExtensionSemaphoreWait MJ_LOCK(signalSemaphore)
-#define MJExtensionSemaphoreSignal MJ_UNLOCK(signalSemaphore)
 
 // 过期
 #define MJExtensionDeprecated(instead) NS_DEPRECATED(2_0, 2_0, 2_0, 2_0, instead)

--- a/MJExtension/NSObject+MJClass.m
+++ b/MJExtension/NSObject+MJClass.m
@@ -17,6 +17,8 @@ static const char MJIgnoredPropertyNamesKey = '\0';
 static const char MJAllowedCodingPropertyNamesKey = '\0';
 static const char MJIgnoredCodingPropertyNamesKey = '\0';
 
+extern dispatch_semaphore_t signalSemaphore;
+
 @implementation NSObject (MJClass)
 
 + (NSMutableDictionary *)mj_classDictForKey:(const void *)key
@@ -139,16 +141,15 @@ static const char MJIgnoredCodingPropertyNamesKey = '\0';
     }
     
     // 清空数据
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
     [[self mj_classDictForKey:key] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    dispatch_semaphore_signal(signalSemaphore);
 }
 
 + (NSMutableArray *)mj_totalObjectsWithSelector:(SEL)selector key:(const char *)key
 {
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    
+    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
     NSMutableArray *array = [self mj_classDictForKey:key][NSStringFromClass(self)];
     if (array == nil) {
         // 创建、存储
@@ -169,7 +170,7 @@ static const char MJIgnoredCodingPropertyNamesKey = '\0';
             [array addObjectsFromArray:subArray];
         }];
     }
-    MJExtensionSemaphoreSignal
+    dispatch_semaphore_signal(signalSemaphore);
     return array;
 }
 @end

--- a/MJExtension/NSObject+MJClass.m
+++ b/MJExtension/NSObject+MJClass.m
@@ -141,15 +141,15 @@ extern dispatch_semaphore_t signalSemaphore;
     }
     
     // 清空数据
-    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
+    MJ_LOCK(signalSemaphore);
     [[self mj_classDictForKey:key] removeAllObjects];
-    dispatch_semaphore_signal(signalSemaphore);
+    MJ_UNLOCK(signalSemaphore);
 }
 
 + (NSMutableArray *)mj_totalObjectsWithSelector:(SEL)selector key:(const char *)key
 {
     
-    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
+    MJ_LOCK(signalSemaphore);
     NSMutableArray *array = [self mj_classDictForKey:key][NSStringFromClass(self)];
     if (array == nil) {
         // 创建、存储
@@ -170,7 +170,7 @@ extern dispatch_semaphore_t signalSemaphore;
             [array addObjectsFromArray:subArray];
         }];
     }
-    dispatch_semaphore_signal(signalSemaphore);
+    MJ_UNLOCK(signalSemaphore);
     return array;
 }
 @end

--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -133,9 +133,9 @@ dispatch_semaphore_t signalSemaphore;
 + (void)mj_enumerateProperties:(MJPropertiesEnumeration)enumeration
 {
     // 获得成员变量
-    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
+    MJ_LOCK(signalSemaphore);
     NSArray *cachedProperties = [self mj_properties];
-    dispatch_semaphore_signal(signalSemaphore);
+    MJ_UNLOCK(signalSemaphore);
     // 遍历成员变量
     BOOL stop = NO;
     for (MJProperty *property in [cachedProperties copy]) {
@@ -210,9 +210,9 @@ dispatch_semaphore_t signalSemaphore;
 {
     [self mj_setupBlockReturnValue:objectClassInArray key:&MJObjectClassInArrayKey];
     
-    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
+    MJ_LOCK(signalSemaphore);
     [[self mj_propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    dispatch_semaphore_signal(signalSemaphore);
+    MJ_UNLOCK(signalSemaphore);
 }
 
 #pragma mark - key配置
@@ -220,18 +220,18 @@ dispatch_semaphore_t signalSemaphore;
 {
     [self mj_setupBlockReturnValue:replacedKeyFromPropertyName key:&MJReplacedKeyFromPropertyNameKey];
     
-    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
+    MJ_LOCK(signalSemaphore);
     [[self mj_propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    dispatch_semaphore_signal(signalSemaphore);
+    MJ_UNLOCK(signalSemaphore);
 }
 
 + (void)mj_setupReplacedKeyFromPropertyName121:(MJReplacedKeyFromPropertyName121)replacedKeyFromPropertyName121
 {
     objc_setAssociatedObject(self, &MJReplacedKeyFromPropertyName121Key, replacedKeyFromPropertyName121, OBJC_ASSOCIATION_COPY_NONATOMIC);
     
-    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
+    MJ_LOCK(signalSemaphore);
     [[self mj_propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    dispatch_semaphore_signal(signalSemaphore);
+    MJ_UNLOCK(signalSemaphore);
 }
 @end
 #pragma clang diagnostic pop

--- a/MJExtension/NSObject+MJProperty.m
+++ b/MJExtension/NSObject+MJProperty.m
@@ -25,7 +25,17 @@ static const char MJObjectClassInArrayKey = '\0';
 
 static const char MJCachedPropertiesKey = '\0';
 
+dispatch_semaphore_t signalSemaphore;
+
 @implementation NSObject (Property)
+
++ (void)load
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        signalSemaphore = dispatch_semaphore_create(1);
+    });
+}
 
 + (NSMutableDictionary *)mj_propertyDictForKey:(const void *)key
 {
@@ -123,10 +133,9 @@ static const char MJCachedPropertiesKey = '\0';
 + (void)mj_enumerateProperties:(MJPropertiesEnumeration)enumeration
 {
     // 获得成员变量
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
     NSArray *cachedProperties = [self mj_properties];
-    MJExtensionSemaphoreSignal
+    dispatch_semaphore_signal(signalSemaphore);
     // 遍历成员变量
     BOOL stop = NO;
     for (MJProperty *property in [cachedProperties copy]) {
@@ -201,10 +210,9 @@ static const char MJCachedPropertiesKey = '\0';
 {
     [self mj_setupBlockReturnValue:objectClassInArray key:&MJObjectClassInArrayKey];
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
     [[self mj_propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    dispatch_semaphore_signal(signalSemaphore);
 }
 
 #pragma mark - key配置
@@ -212,20 +220,18 @@ static const char MJCachedPropertiesKey = '\0';
 {
     [self mj_setupBlockReturnValue:replacedKeyFromPropertyName key:&MJReplacedKeyFromPropertyNameKey];
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
     [[self mj_propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    dispatch_semaphore_signal(signalSemaphore);
 }
 
 + (void)mj_setupReplacedKeyFromPropertyName121:(MJReplacedKeyFromPropertyName121)replacedKeyFromPropertyName121
 {
     objc_setAssociatedObject(self, &MJReplacedKeyFromPropertyName121Key, replacedKeyFromPropertyName121, OBJC_ASSOCIATION_COPY_NONATOMIC);
     
-    MJExtensionSemaphoreCreate
-    MJExtensionSemaphoreWait
+    dispatch_semaphore_wait(signalSemaphore, DISPATCH_TIME_FOREVER);
     [[self mj_propertyDictForKey:&MJCachedPropertiesKey] removeAllObjects];
-    MJExtensionSemaphoreSignal
+    dispatch_semaphore_signal(signalSemaphore);
 }
 @end
 #pragma clang diagnostic pop


### PR DESCRIPTION
修饰信号量的 static 放到了函数内了，导致信号量所不生效，多线程下访问model.mj_keyValues和[model mj_setupReplacedKeyFromPropertyName] 会出现崩溃