### PR TITLE
Add NSSecureCoding support for quick implementation macro `MJSecureCodingImplementation(class, isSupport)`.

### DIFF
--- a/MJExtension/NSObject+MJCoding.h
+++ b/MJExtension/NSObject+MJCoding.h
@@ -50,6 +50,17 @@ return self; \
 - (void)encodeWithCoder:(NSCoder *)encoder \
 { \
 [self mj_encode:encoder]; \
-}
+}\
 
 #define MJExtensionCodingImplementation MJCodingImplementation
+
+#define MJExtensionSecureCodingImplementationSupport(CLASS, FLAG) \
+@interface CLASS (MJSecureCoding) <NSSecureCoding> \
+@end \
+@implementation CLASS (MJSecureCoding) \
+MJCodingImplementation \
++ (BOOL)supportsSecureCoding { \
+return FLAG; \
+} \
+@end \
+

--- a/MJExtension/NSObject+MJCoding.h
+++ b/MJExtension/NSObject+MJCoding.h
@@ -54,7 +54,7 @@ return self; \
 
 #define MJExtensionCodingImplementation MJCodingImplementation
 
-#define MJExtensionSecureCodingImplementationSupport(CLASS, FLAG) \
+#define MJSecureCodingImplementation(CLASS, FLAG) \
 @interface CLASS (MJSecureCoding) <NSSecureCoding> \
 @end \
 @implementation CLASS (MJSecureCoding) \

--- a/MJExtension/NSObject+MJCoding.m
+++ b/MJExtension/NSObject+MJCoding.m
@@ -43,7 +43,8 @@
         if (allowedCodingPropertyNames.count && ![allowedCodingPropertyNames containsObject:property.name]) return;
         if ([ignoredCodingPropertyNames containsObject:property.name]) return;
         
-        id value = [decoder decodeObjectForKey:property.name];
+        // fixed `-[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSNumber'(This will be disallowed in the future.)` warning.
+        id value = [decoder decodeObjectOfClasses:[NSSet setWithObjects:NSNumber.class, property.type.typeClass, nil] forKey:property.name];
         if (value == nil) { // 兼容以前的MJExtension版本
             value = [decoder decodeObjectForKey:[@"_" stringByAppendingString:property.name]];
         }

--- a/MJExtensionTests/MJExtensionTests.m
+++ b/MJExtensionTests/MJExtensionTests.m
@@ -19,6 +19,7 @@
 #import <CoreData/CoreData.h>
 #import "MJFrenchUser.h"
 #import "MJCat.h"
+#import <MJExtensionTests-Swift.h>
 
 @interface MJExtensionTests : XCTestCase
 
@@ -440,13 +441,20 @@
     MJBag *bag = [[MJBag alloc] init];
     bag.name = @"Red bag";
     bag.price = 200.8;
+    bag.isBig = YES;
+    bag.weight = 200;
     
     NSString *file = [NSTemporaryDirectory() stringByAppendingPathComponent:@"bag.data"];
-    // 归档
-    [NSKeyedArchiver archiveRootObject:bag toFile:file];
     
+    NSError *error = nil;
+    // 归档
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:bag requiringSecureCoding:YES error:&error];
+    [data writeToFile:file atomically:true];
+
     // 解档
-    MJBag *decodedBag = [NSKeyedUnarchiver unarchiveObjectWithFile:file];
+    NSData *readData = [NSFileManager.defaultManager contentsAtPath:file];
+    error = nil;
+    MJBag *decodedBag = [NSKeyedUnarchiver unarchivedObjectOfClass:MJBag.class fromData:readData error:&error];
     MJExtensionLog(@"name=%@, price=%f", decodedBag.name, decodedBag.price);
 }
 

--- a/MJExtensionTests/Model/MJBag.h
+++ b/MJExtensionTests/Model/MJBag.h
@@ -11,4 +11,6 @@
 @interface MJBag : NSObject
 @property (copy, nonatomic) NSString *name;
 @property (assign, nonatomic) double price;
+@property (nonatomic) BOOL isBig;
+@property (nonatomic) NSInteger weight;
 @end

--- a/MJExtensionTests/Model/MJBag.m
+++ b/MJExtensionTests/Model/MJBag.m
@@ -10,9 +10,10 @@
 
 @import MJExtension;
 
+// NSSecureCoding实现
+MJExtensionSecureCodingImplementationSupport(MJBag, YES)
+
 @implementation MJBag
-// NSCoding实现
-MJExtensionCodingImplementation
 
 //+ (NSArray *)mj_ignoredCodingPropertyNames
 //{

--- a/MJExtensionTests/Model/MJBag.m
+++ b/MJExtensionTests/Model/MJBag.m
@@ -11,7 +11,7 @@
 @import MJExtension;
 
 // NSSecureCoding实现
-MJExtensionSecureCodingImplementationSupport(MJBag, YES)
+MJSecureCodingImplementation(MJBag, YES)
 
 @implementation MJBag
 

--- a/README.md
+++ b/README.md
@@ -489,10 +489,10 @@ bag.name = @"Red bag";
 bag.price = 200.8;
 
 NSString *file = [NSHomeDirectory() stringByAppendingPathComponent:@"Desktop/bag.data"];
-// Encoding
+// Encoding by archiving
 [NSKeyedArchiver archiveRootObject:bag toFile:file];
 
-// Decoding
+// Decoding by unarchiving
 Bag *decodedBag = [NSKeyedUnarchiver unarchiveObjectWithFile:file];
 NSLog(@"name=%@, price=%f", decodedBag.name, decodedBag.price);
 // name=(null), price=200.800000
@@ -529,11 +529,11 @@ bag.weight = 200;
 NSString *file = [NSTemporaryDirectory() stringByAppendingPathComponent:@"bag.data"];
 
 NSError *error = nil;
-// Encoding
+// Encoding by archiving
 NSData *data = [NSKeyedArchiver archivedDataWithRootObject:bag requiringSecureCoding:YES error:&error];
 [data writeToFile:file atomically:true];
 
-// Decoding
+// Decoding by unarchiving
 NSData *readData = [NSFileManager.defaultManager contentsAtPath:file];
 error = nil;
 MJBag *decodedBag = [NSKeyedUnarchiver unarchivedObjectOfClass:MJBag.class fromData:readData error:&error];

--- a/README.md
+++ b/README.md
@@ -470,21 +470,21 @@ User *user = [User mj_objectWithKeyValues:dict context:context];
 ```objc
 #import "MJExtension.h"
 
-@implementation Bag
+@implementation MJBag
 // NSCoding Implementation
-MJExtensionCodingImplementation
+MJCodingImplementation
 @end
 
 /***********************************************/
 
 // what properties not to be coded
-[Bag mj_setupIgnoredCodingPropertyNames:^NSArray *{
+[MJBag mj_setupIgnoredCodingPropertyNames:^NSArray *{
     return @[@"name"];
 }];
-// Equals: Bag.m implements +mj_ignoredCodingPropertyNames method.
+// Equals: MJBag.m implements +mj_ignoredCodingPropertyNames method.
 
 // Create model
-Bag *bag = [[Bag alloc] init];
+MJBag *bag = [[MJBag alloc] init];
 bag.name = @"Red bag";
 bag.price = 200.8;
 
@@ -493,20 +493,20 @@ NSString *file = [NSHomeDirectory() stringByAppendingPathComponent:@"Desktop/bag
 [NSKeyedArchiver archiveRootObject:bag toFile:file];
 
 // Decoding by unarchiving
-Bag *decodedBag = [NSKeyedUnarchiver unarchiveObjectWithFile:file];
+MJBag *decodedBag = [NSKeyedUnarchiver unarchiveObjectWithFile:file];
 NSLog(@"name=%@, price=%f", decodedBag.name, decodedBag.price);
 // name=(null), price=200.800000
 ```
 
 ### <a id="SecureCoding"></a> Secure Coding
 
-Using `MJExtensionSecureCodingImplementationSupport(class, isSupport)` macro.
+Using `MJSecureCodingImplementation(class, isSupport)` macro.
 
 ```objc
 @import MJExtension;
 
 // NSSecureCoding Implementation
-MJExtensionSecureCodingImplementationSupport(MJBag, YES)
+MJSecureCodingImplementation(MJBag, YES)
 
 @implementation MJBag
 @end
@@ -514,10 +514,10 @@ MJExtensionSecureCodingImplementationSupport(MJBag, YES)
  /***********************************************/
 
 // what properties not to be coded
-[Bag mj_setupIgnoredCodingPropertyNames:^NSArray *{
+[MJBag mj_setupIgnoredCodingPropertyNames:^NSArray *{
     return @[@"name"];
 }];
-// Equals: Bag.m implements +mj_ignoredCodingPropertyNames method.
+// Equals: MJBag.m implements +mj_ignoredCodingPropertyNames method.
 
 // Create model
 MJBag *bag = [[MJBag alloc] init];


### PR DESCRIPTION
## Why
Old archive and unarchive methods are deprecated since `iOS 12`. So supporting secure coding is necessary job to accomplish.

## How to use
Using `MJSecureCodingImplementation(class, isSupport)` macro to implement `NSSecureCoding` in a quite easy way, just like old `MJCodingImplementation`.

## Archive and Unarchive
```objc
NSError *error = nil;
// Archive
NSData *data = [NSKeyedArchiver archivedDataWithRootObject:bag requiringSecureCoding:YES error:&error];
[data writeToFile:file atomically:true];

// Unarchive
NSData *readData = [NSFileManager.defaultManager contentsAtPath:file];
error = nil;
MJBag *decodedBag = [NSKeyedUnarchiver unarchivedObjectOfClass:MJBag.class fromData:readData error:&error];
```