### PR TITLE
add type check when it is class  foundation

### DIFF
--- a/MJExtension/NSObject+MJKeyValue.m
+++ b/MJExtension/NSObject+MJKeyValue.m
@@ -290,8 +290,16 @@ static const char MJReferenceReplacedKeyWhenCreatingKeyValuesKey = '\0';
     MJExtensionAssertError([keyValuesArray isKindOfClass:[NSArray class]], nil, [self class], @"keyValuesArray参数不是一个数组");
     
     // 如果数组里面放的是NSString、NSNumber等数据
-    if ([MJFoundation isClassFromFoundation:self]) return [NSMutableArray arrayWithArray:keyValuesArray];
-    
+    // 则直接判断类型是否一致
+    if ([MJFoundation isClassFromFoundation:self]) {
+        NSMutableArray *modelArray = [NSMutableArray array];
+        [keyValuesArray enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            if ([obj isKindOfClass:self]) {
+                [modelArray addObject:obj];
+            }
+        }];
+        return modelArray;
+    }
 
     // 2.创建数组
     NSMutableArray *modelArray = [NSMutableArray array];


### PR DESCRIPTION
如果一个类的定义为：
```objective-c
@interface MJPerson : NSObject
@property (copy, nonatomic) NSString *name;
@property (nonatomic) BOOL isVIP;
@property (strong, nonatomic) NSArray<MJPerson *> *friends;
@property (strong, nonatomic) NSArray<NSString *> *books;
@end
```
但是给的 json 数据形如：
```json
{
    "name": "myName",
    "isVIP": false,
    "friends": [],
    "books": ["book1", "book2", null, false, 123]
}
```
此时获得的模型中，books 属性就不能保证是 `NSString` 了